### PR TITLE
Fixes the broken ES|QL editor storybook

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/__stories__/esql_editor.stories.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/__stories__/esql_editor.stories.tsx
@@ -18,6 +18,7 @@ const Template = (args: ESQLEditorProps) => (
     services={{
       settings: { client: { get: () => {} } },
       uiSettings: { get: () => {} },
+      data: { query: { timefilter: { timefilter: { getTime: () => {} } } } },
     }}
   >
     <ESQLEditor {...args} />
@@ -37,7 +38,6 @@ export const ExpandedMode: StoryObj<typeof ESQLEditor> = {
     query: {
       esql: 'from dataview | keep field1, field2',
     },
-    dataTestSubj: 'test-id',
   },
 
   argTypes: {


### PR DESCRIPTION
## Summary

This is fixing the broken stories for the ES|QL editor 

<img width="1021" alt="image" src="https://github.com/user-attachments/assets/9f033ea7-d1cd-4ca8-aa76-0d8d9e6fb4a0" />

(We need to update it with more cases but this can happen on a follow up PR)



